### PR TITLE
Add navigable menu home page

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+import styles from '../styles/Layout.module.css';
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function Layout({ children }: Props) {
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Agent Bill</h1>
+        <nav className={styles.nav}>
+          <Link href="/">Home</Link>
+          <Link href="/upload">Upload Bill</Link>
+          <Link href="/spreadsheet">Spreadsheet</Link>
+          <Link href="/history">History</Link>
+          <Link href="/settings">Settings</Link>
+        </nav>
+      </header>
+      <main className={styles.main}>{children}</main>
+    </div>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,8 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from 'next';
+import Layout from '../components/Layout';
+
+const History: NextPage = () => (
+  <Layout>
+    <h2>History</h2>
+    <p>Here you will find previously processed files.</p>
+  </Layout>
+);
+
+export default History;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,31 @@
 import type { NextPage } from 'next';
+import Link from 'next/link';
+import Layout from '../components/Layout';
+import styles from '../styles/Home.module.css';
 
 const Home: NextPage = () => {
-  return <div>Welcome to AgentBill</div>;
+  return (
+    <Layout>
+      <div className={styles.grid}>
+        <Link href="/upload" className={styles.card}>
+          <h2>Upload Bill &rarr;</h2>
+          <p>Send an image or PDF for processing.</p>
+        </Link>
+        <Link href="/spreadsheet" className={styles.card}>
+          <h2>Spreadsheet &rarr;</h2>
+          <p>View all your bills in Google Sheets.</p>
+        </Link>
+        <Link href="/history" className={styles.card}>
+          <h2>History &rarr;</h2>
+          <p>Check previously processed files.</p>
+        </Link>
+        <Link href="/settings" className={styles.card}>
+          <h2>Settings &rarr;</h2>
+          <p>Configure your Google integration.</p>
+        </Link>
+      </div>
+    </Layout>
+  );
 };
 
 export default Home;

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from 'next';
+import Layout from '../components/Layout';
+
+const Settings: NextPage = () => (
+  <Layout>
+    <h2>Settings</h2>
+    <p>Configure your account and integrations here.</p>
+  </Layout>
+);
+
+export default Settings;

--- a/pages/spreadsheet.tsx
+++ b/pages/spreadsheet.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from 'next';
+import Layout from '../components/Layout';
+
+const Spreadsheet: NextPage = () => (
+  <Layout>
+    <h2>Spreadsheet</h2>
+    <p>This page will display your Google Sheet data.</p>
+  </Layout>
+);
+
+export default Spreadsheet;

--- a/pages/upload.tsx
+++ b/pages/upload.tsx
@@ -1,0 +1,11 @@
+import type { NextPage } from 'next';
+import Layout from '../components/Layout';
+
+const Upload: NextPage = () => (
+  <Layout>
+    <h2>Upload Bill</h2>
+    <p>This is a placeholder page for uploading bills.</p>
+  </Layout>
+);
+
+export default Upload;

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,0 +1,29 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  padding: 1.5rem;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: block;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.card h2 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.2rem;
+}
+
+.card p {
+  margin: 0;
+  color: #666;
+}

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -1,0 +1,39 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.header {
+  background-color: #2c3e50;
+  padding: 1rem;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav a {
+  color: #ecf0f1;
+  transition: color 0.2s ease;
+}
+
+.nav a:hover {
+  color: #ffffff;
+  text-decoration: underline;
+}
+
+.main {
+  flex: 1;
+  padding: 2rem;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,15 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- implement `_app.tsx` with global CSS
- add `Layout` component with navigation menu
- create an appealing home page using cards
- add placeholder pages for main sections
- style layout and menu

## Testing
- `npm test`