### PR TITLE
Add error handling for missing Google OAuth client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ For more details about how the project integrates with Google services and OpenA
 
 High level user stories and requirements are stored in the [docs/user_stories.md](docs/user_stories.md) file. Detailed descriptions can be found in [docs/detailed_user_stories.md](docs/detailed_user_stories.md).
 
+## Google OAuth Setup
+
+Set the `NEXT_PUBLIC_GOOGLE_CLIENT_ID` environment variable with the client ID of your Google OAuth application. The redirect URL should point to `/oauth2callback` on your deployed site. This variable must be provided when the app is built. If it is missing, the **Connect Google** button will show an error instead of redirecting to Google.
+
 ## Deployment
 
 The repository includes a GitHub Actions workflow that deploys the Next.js application to Vercel whenever changes are pushed to `main`. Setup instructions are available in [docs/deploy_vercel.md](docs/deploy_vercel.md).

--- a/pages/oauth2callback.tsx
+++ b/pages/oauth2callback.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import Layout from '../components/Layout';
+
+export default function OAuthCallback() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const hash = window.location.hash.substring(1);
+      const params = new URLSearchParams(hash);
+      const token = params.get('access_token');
+      if (token) {
+        localStorage.setItem('googleToken', token);
+        router.replace('/settings?status=success');
+      } else {
+        router.replace('/settings?status=error');
+      }
+    }
+  }, [router]);
+
+  return (
+    <Layout>
+      <p>Processing authentication...</p>
+    </Layout>
+  );
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,11 +1,74 @@
 import type { NextPage } from 'next';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import Layout from '../components/Layout';
+import styles from '../styles/Settings.module.css';
 
-const Settings: NextPage = () => (
-  <Layout>
-    <h2>Settings</h2>
-    <p>Configure your account and integrations here.</p>
-  </Layout>
-);
+const Settings: NextPage = () => {
+  const router = useRouter();
+  const [connected, setConnected] = useState(false);
+  const [message, setMessage] = useState('');
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('googleToken');
+    setConnected(!!token);
+  }, []);
+
+  useEffect(() => {
+    if (router.query.status === 'success') {
+      setMessage('Google account connected!');
+      setIsError(false);
+      setConnected(true);
+    } else if (router.query.status === 'error') {
+      setMessage('Failed to authenticate with Google.');
+      setIsError(true);
+    }
+  }, [router.query.status]);
+
+  const connect = () => {
+    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    if (!clientId) {
+      setMessage('Google OAuth client ID is not configured.');
+      setIsError(true);
+      return;
+    }
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: `${window.location.origin}/oauth2callback`,
+      response_type: 'token',
+      scope:
+        'https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets',
+      include_granted_scopes: 'true',
+    });
+    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+  };
+
+  const disconnect = () => {
+    localStorage.removeItem('googleToken');
+    setConnected(false);
+    setMessage('Google account disconnected.');
+    setIsError(false);
+  };
+
+  return (
+    <Layout>
+      <h2>Settings</h2>
+      {message && (
+        <div className={`${styles.message} ${isError ? styles.error : styles.success}`}>{message}</div>
+      )}
+      {connected ? (
+        <button onClick={disconnect} className={styles.button}>
+          Disconnect Google
+        </button>
+      ) : (
+        <button onClick={connect} className={styles.button}>
+          Connect Google
+        </button>
+      )}
+    </Layout>
+  );
+};
 
 export default Settings;

--- a/styles/Settings.module.css
+++ b/styles/Settings.module.css
@@ -1,0 +1,20 @@
+.message {
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  border-radius: 4px;
+}
+
+.success {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.error {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+.button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- prevent OAuth redirect when client ID isn't configured
- document requirement for NEXT_PUBLIC_GOOGLE_CLIENT_ID

## Testing
- `npm test`
