### PR TITLE
Secure settings storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ High level user stories and requirements are stored in the [docs/user_stories.md
 
 Set the `NEXT_PUBLIC_GOOGLE_CLIENT_ID` environment variable with the client ID of your Google OAuth application. The redirect URL should point to `/oauth2callback` on your deployed site. Once configured, you can connect or disconnect your Google account from the **Settings** page. If the variable is missing, the **Connect** button will display an error and no OAuth request will be made.
 
+## Secure Configuration Storage
+
+The Settings page persists the Google OAuth token and your OpenAI API key using HTTP-only cookies. These cookies are set via the `/api/config` endpoint and cannot be accessed from JavaScript, providing basic protection against XSS. The stored values remain available after a page refresh. You can remove them at any time using the **Disconnect Google** or **Remove Key** buttons.
+
 ## Deployment
 
 The repository includes a GitHub Actions workflow that deploys the Next.js application to Vercel whenever changes are pushed to `main`. Setup instructions are available in [docs/deploy_vercel.md](docs/deploy_vercel.md).

--- a/pages/api/config.ts
+++ b/pages/api/config.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const hasGoogleToken = Boolean(req.cookies.googleToken);
+    const hasOpenAIKey = Boolean(req.cookies.openaiKey);
+    res.status(200).json({ hasGoogleToken, hasOpenAIKey });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const cookies: string[] = [];
+    if (req.body.googleToken) {
+      cookies.push(`googleToken=${req.body.googleToken}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`);
+    }
+    if (req.body.openaiKey) {
+      cookies.push(`openaiKey=${req.body.openaiKey}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`);
+    }
+    if (cookies.length) {
+      res.setHeader('Set-Cookie', cookies);
+    }
+    res.status(200).json({ ok: true });
+    return;
+  }
+
+  if (req.method === 'DELETE') {
+    const cookies: string[] = [];
+    if (req.query.key === 'google' || !req.query.key) {
+      cookies.push('googleToken=; Path=/; HttpOnly; Max-Age=0; SameSite=Lax');
+    }
+    if (req.query.key === 'openai' || !req.query.key) {
+      cookies.push('openaiKey=; Path=/; HttpOnly; Max-Age=0; SameSite=Lax');
+    }
+    if (cookies.length) {
+      res.setHeader('Set-Cookie', cookies);
+    }
+    res.status(200).json({ ok: true });
+    return;
+  }
+
+  res.status(405).end();
+}

--- a/pages/oauth2callback.tsx
+++ b/pages/oauth2callback.tsx
@@ -11,8 +11,13 @@ export default function OAuthCallback() {
       const params = new URLSearchParams(hash);
       const token = params.get('access_token');
       if (token) {
-        localStorage.setItem('googleToken', token);
-        router.replace('/settings?status=success');
+        fetch('/api/config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ googleToken: token }),
+        })
+          .then(() => router.replace('/settings?status=success'))
+          .catch(() => router.replace('/settings?status=error'));
       } else {
         router.replace('/settings?status=error');
       }

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -10,15 +10,15 @@ const Settings: NextPage = () => {
   const [message, setMessage] = useState('');
   const [isError, setIsError] = useState(false);
   const [openAIKey, setOpenAIKey] = useState('');
+  const [keyStored, setKeyStored] = useState(false);
 
   useEffect(() => {
-    const storedKey = localStorage.getItem('openaiKey') || '';
-    setOpenAIKey(storedKey);
-  }, []);
-
-  useEffect(() => {
-    const token = localStorage.getItem('googleToken');
-    setConnected(!!token);
+    fetch('/api/config')
+      .then((res) => res.json())
+      .then((data) => {
+        setConnected(data.hasGoogleToken);
+        setKeyStored(data.hasOpenAIKey);
+      });
   }, []);
 
   useEffect(() => {
@@ -52,10 +52,11 @@ const Settings: NextPage = () => {
   };
 
   const disconnect = () => {
-    localStorage.removeItem('googleToken');
-    setConnected(false);
-    setMessage('Google account disconnected.');
-    setIsError(false);
+    fetch('/api/config?key=google', { method: 'DELETE' }).then(() => {
+      setConnected(false);
+      setMessage('Google account disconnected.');
+      setIsError(false);
+    });
   };
 
   const isValidOpenAIKey = (key: string) => key.startsWith('sk-') && key.length > 40;
@@ -65,9 +66,24 @@ const Settings: NextPage = () => {
       alert('Invalid OpenAI API key.');
       return;
     }
-    localStorage.setItem('openaiKey', openAIKey);
-    setMessage('OpenAI API key saved!');
-    setIsError(false);
+    fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ openaiKey: openAIKey }),
+    }).then(() => {
+      setKeyStored(true);
+      setOpenAIKey('');
+      setMessage('OpenAI API key saved!');
+      setIsError(false);
+    });
+  };
+
+  const deleteKey = () => {
+    fetch('/api/config?key=openai', { method: 'DELETE' }).then(() => {
+      setKeyStored(false);
+      setMessage('OpenAI API key removed.');
+      setIsError(false);
+    });
   };
 
   return (
@@ -88,6 +104,14 @@ const Settings: NextPage = () => {
         <button onClick={saveKey} className={styles.button}>
           Save Key
         </button>
+        {keyStored && (
+          <>
+            <span className={styles.note}>Key stored securely</span>
+            <button onClick={deleteKey} className={styles.button}>
+              Remove Key
+            </button>
+          </>
+        )}
       </div>
       {connected ? (
         <button onClick={disconnect} className={styles.button}>

--- a/styles/Settings.module.css
+++ b/styles/Settings.module.css
@@ -31,3 +31,9 @@
   margin: 0.5rem 0;
   font-size: 1rem;
 }
+
+.note {
+  margin-left: 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
+}


### PR DESCRIPTION
## Summary
- store Google credentials and OpenAI keys in HTTP-only cookies via new `/api/config` endpoint
- update OAuth callback and settings page to use the new API
- show key status in settings UI
- document secure storage in README
- fix variable name in settings page

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm test`
