### PR TITLE
Add privacy and terms pages

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -17,6 +17,8 @@ export default function Layout({ children }: Props) {
           <Link href="/spreadsheet">Spreadsheet</Link>
           <Link href="/history">History</Link>
           <Link href="/settings">Settings</Link>
+          <Link href="/privacy">Privacy Policy</Link>
+          <Link href="/terms">Terms of Service</Link>
         </nav>
       </header>
       <main className={styles.main}>{children}</main>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,6 +23,14 @@ const Home: NextPage = () => {
           <h2>Settings &rarr;</h2>
           <p>Configure your Google integration.</p>
         </Link>
+        <Link href="/privacy" className={styles.card}>
+          <h2>Privacy Policy &rarr;</h2>
+          <p>Leia nossa política de privacidade.</p>
+        </Link>
+        <Link href="/terms" className={styles.card}>
+          <h2>Terms of Service &rarr;</h2>
+          <p>Veja os termos que regem o uso do site.</p>
+        </Link>
       </div>
     </Layout>
   );

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,0 +1,14 @@
+import type { NextPage } from 'next';
+import Layout from '../components/Layout';
+
+const Privacy: NextPage = () => (
+  <Layout>
+    <h2>Política de Privacidade</h2>
+    <p>Esta Política de Privacidade descreve como suas informações pessoais são coletadas, usadas e compartilhadas ao utilizar este site.</p>
+    <p>Coletamos informações fornecidas voluntariamente e dados de uso gerados automaticamente. Esses dados são usados para operar e aprimorar o serviço.</p>
+    <p>Ao continuar a utilizar o site, você concorda com esta Política. Podemos atualizá-la periodicamente e as alterações entrarão em vigor quando publicadas nesta página.</p>
+    <p>Se tiver qualquer dúvida, entre em contato conosco.</p>
+  </Layout>
+);
+
+export default Privacy;

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -1,0 +1,14 @@
+import type { NextPage } from 'next';
+import Layout from '../components/Layout';
+
+const Terms: NextPage = () => (
+  <Layout>
+    <h2>Termos de Serviço</h2>
+    <p>Ao acessar ou utilizar este site, você concorda em cumprir estes Termos de Serviço e todas as leis e regulamentos aplicáveis.</p>
+    <p>O conteúdo é fornecido "no estado em que se encontra" e pode ser alterado ou removido a qualquer momento, sem aviso prévio.</p>
+    <p>Não garantimos que o serviço estará disponível de forma ininterrupta ou livre de erros. O uso é por sua conta e risco.</p>
+    <p>Podemos modificar estes Termos a qualquer momento. O uso continuado do site após a publicação das alterações significa que você aceita os Termos atualizados.</p>
+  </Layout>
+);
+
+export default Terms;


### PR DESCRIPTION
## Summary
- add Portuguese privacy policy page
- add Portuguese terms of service page
- link to policy and terms in navigation menu
- show policy and terms links on home page

## Testing
- `npm test`