### PR TITLE
Move legal links to footer

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -17,11 +17,13 @@ export default function Layout({ children }: Props) {
           <Link href="/spreadsheet">Spreadsheet</Link>
           <Link href="/history">History</Link>
           <Link href="/settings">Settings</Link>
-          <Link href="/privacy">Privacy Policy</Link>
-          <Link href="/terms">Terms of Service</Link>
         </nav>
       </header>
       <main className={styles.main}>{children}</main>
+      <footer className={styles.footer}>
+        <Link href="/privacy">Privacy Policy</Link> |{' '}
+        <Link href="/terms">Terms of Service</Link>
+      </footer>
     </div>
   );
 }

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -37,3 +37,9 @@
   flex: 1;
   padding: 2rem;
 }
+
+.footer {
+  background-color: #f5f5f5;
+  padding: 1rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- show legal policy links in the footer
- remove privacy and terms from top navigation

## Testing
- `npm test`