### PR TITLE
Add Google connection status

### DIFF
--- a/pages/api/userinfo.ts
+++ b/pages/api/userinfo.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const token = req.cookies.googleToken;
+  if (!token) {
+    res.status(401).json({ error: 'Not connected' });
+    return;
+  }
+
+  try {
+    const response = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      res.status(500).json({ error: 'Failed to fetch user info' });
+      return;
+    }
+    const data = await response.json();
+    res.status(200).json({ email: data.email, picture: data.picture });
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch user info' });
+  }
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -12,6 +12,8 @@ const Settings: NextPage = () => {
   const [openAIKey, setOpenAIKey] = useState('');
   const [keyStored, setKeyStored] = useState(false);
   const [showRetry, setShowRetry] = useState(false);
+  const [userEmail, setUserEmail] = useState('');
+  const [userIcon, setUserIcon] = useState('');
 
   useEffect(() => {
     fetch('/api/config')
@@ -21,6 +23,24 @@ const Settings: NextPage = () => {
         setKeyStored(data.hasOpenAIKey);
       });
   }, []);
+
+  useEffect(() => {
+    if (connected) {
+      fetch('/api/userinfo')
+        .then((res) => (res.ok ? res.json() : Promise.reject()))
+        .then((data) => {
+          setUserEmail(data.email);
+          setUserIcon(data.picture);
+        })
+        .catch(() => {
+          setUserEmail('');
+          setUserIcon('');
+        });
+    } else {
+      setUserEmail('');
+      setUserIcon('');
+    }
+  }, [connected]);
 
   useEffect(() => {
     if (router.query.status === 'success') {
@@ -50,7 +70,7 @@ const Settings: NextPage = () => {
       redirect_uri: `${window.location.origin}/oauth2callback`,
       response_type: 'token',
       scope:
-        'https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets',
+        'https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile',
       include_granted_scopes: 'true',
     });
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
@@ -129,6 +149,21 @@ const Settings: NextPage = () => {
         </div>
         <div className={`${styles.section} ${styles.googleSection}`}>
           <h3 className={styles.sectionTitle}>Google Settings</h3>
+          <div className={styles.status}>
+            {connected ? (
+              <>
+                {userIcon && (
+                  <img src={userIcon} alt="account" className={styles.profileIcon} />
+                )}
+                <span>{userEmail}</span>
+              </>
+            ) : (
+              <>
+                <span className={styles.notConnected}>X</span>
+                <span className={styles.notConnected}>Not connected</span>
+              </>
+            )}
+          </div>
           {connected ? (
             <button onClick={disconnect} className={styles.button}>
               Disconnect Google

--- a/styles/Settings.module.css
+++ b/styles/Settings.module.css
@@ -70,3 +70,21 @@
   font-size: 0.9rem;
   color: #555;
 }
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.profileIcon {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}
+
+.notConnected {
+  color: #d32f2f;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- show connected Google account email and icon on Settings page
- add red X indicator when no connection
- add endpoint to fetch user info via People API
- update styles for connection status
- include email/profile scopes in OAuth flow

## Testing
- `npm test`
- `npm run build` *(fails: `next` not found)*