### PR TITLE
Display Google account name

### DIFF
--- a/pages/api/userinfo.ts
+++ b/pages/api/userinfo.ts
@@ -16,7 +16,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return;
     }
     const data = await response.json();
-    res.status(200).json({ email: data.email, picture: data.picture });
+    res.status(200).json({
+      email: data.email,
+      picture: data.picture,
+      name: data.name,
+    });
   } catch (error) {
     res.status(500).json({ error: 'Failed to fetch user info' });
   }

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -14,6 +14,7 @@ const Settings: NextPage = () => {
   const [showRetry, setShowRetry] = useState(false);
   const [userEmail, setUserEmail] = useState('');
   const [userIcon, setUserIcon] = useState('');
+  const [userName, setUserName] = useState('');
 
   useEffect(() => {
     fetch('/api/config')
@@ -31,14 +32,17 @@ const Settings: NextPage = () => {
         .then((data) => {
           setUserEmail(data.email);
           setUserIcon(data.picture);
+          setUserName(data.name);
         })
         .catch(() => {
           setUserEmail('');
           setUserIcon('');
+          setUserName('');
         });
     } else {
       setUserEmail('');
       setUserIcon('');
+      setUserName('');
     }
   }, [connected]);
 
@@ -155,7 +159,7 @@ const Settings: NextPage = () => {
                 {userIcon && (
                   <img src={userIcon} alt="account" className={styles.profileIcon} />
                 )}
-                <span>{userEmail}</span>
+                <span>{userName} ({userEmail})</span>
               </>
             ) : (
               <>


### PR DESCRIPTION
## Summary
- expose `name` field in `/api/userinfo` route
- store and render the Google account name on the settings page

## Testing
- `npm test`