### PR TITLE
Fix Google OAuth client ID fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ cp .env.example .env.local
 
 Then set the `NEXT_PUBLIC_GOOGLE_CLIENT_ID` environment variable with the client
 ID of your Google OAuth application. The redirect URL should point to
-`/oauth2callback` on your deployed site. Once configured, you can connect or
-disconnect your Google account from the **Settings** page. If the variable is
-missing, the **Connect** button will display an error and no OAuth request will
-be made.
+`/oauth2callback` on your deployed site. A default client ID is bundled with the
+code so the application works out of the box, but you can override it by setting
+your own value. Once configured, you can connect or disconnect your Google
+account from the **Settings** page. If no value is provided, the default ID will
+be used.
 
 ## Secure Configuration Storage
 

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -66,8 +66,12 @@ const Settings: NextPage = () => {
     }
   }, [router.query.status]);
 
+  const GOOGLE_CLIENT_ID =
+    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ||
+    '198927534674-0akhqu4ip9hg276ag2mliknkh7pvp4op.apps.googleusercontent.com';
+
   const connect = () => {
-    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    const clientId = GOOGLE_CLIENT_ID;
     if (!clientId) {
       setMessage('ID de cliente do Google OAuth não configurado. Defina a variável de ambiente NEXT_PUBLIC_GOOGLE_CLIENT_ID.');
       setIsError(true);


### PR DESCRIPTION
## Summary
- provide a bundled default Google OAuth client ID
- document new default behaviour for the ID

## Testing
- `npm test`