### PR TITLE
Hard-code Google OAuth client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ own credentials:
 cp .env.example .env.local
 ```
 
-Then set the `NEXT_PUBLIC_GOOGLE_CLIENT_ID` environment variable with the client
-ID of your Google OAuth application. The redirect URL should point to
+The application ships with a built-in Google OAuth client ID so it runs out of
+the box. If you prefer to use your own ID, update the `GOOGLE_CLIENT_ID`
+constant in `pages/settings.tsx`. The redirect URL should point to
 `/oauth2callback` on your deployed site. Once configured, you can connect or
-disconnect your Google account from the **Settings** page. If the variable is
-missing, the **Connect** button will display an error and no OAuth request will
-be made.
+disconnect your Google account from the **Settings** page.
 
 ## Secure Configuration Storage
 

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -66,10 +66,14 @@ const Settings: NextPage = () => {
     }
   }, [router.query.status]);
 
+  // Hard-coded default Google OAuth client ID so the app works without config
+  const GOOGLE_CLIENT_ID =
+    '198927534674-0akhqu4ip9hg276ag2mliknkh7pvp4op.apps.googleusercontent.com';
+
   const connect = () => {
-    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    const clientId = GOOGLE_CLIENT_ID;
     if (!clientId) {
-      setMessage('ID de cliente do Google OAuth não configurado. Defina a variável de ambiente NEXT_PUBLIC_GOOGLE_CLIENT_ID.');
+      setMessage('ID de cliente do Google OAuth não configurado.');
       setIsError(true);
       return;
     }


### PR DESCRIPTION
## Summary
- hard-code Google client ID directly in settings
- update README to describe the built-in ID and how to change it

## Testing
- `npm test`
