### PR TITLE
Add upload form with file type validation

### DIFF
--- a/pages/upload.tsx
+++ b/pages/upload.tsx
@@ -1,11 +1,47 @@
 import type { NextPage } from 'next';
+import { useRef, useState } from 'react';
 import Layout from '../components/Layout';
+import styles from '../styles/Upload.module.css';
 
-const Upload: NextPage = () => (
-  <Layout>
-    <h2>Enviar Conta</h2>
-    <p>Esta é uma página temporária para envio de contas.</p>
-  </Layout>
-);
+const Upload: NextPage = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState('');
+
+  const handleButtonClick = () => {
+    inputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const validTypes = ['image/png', 'image/jpeg', 'application/pdf'];
+    if (!validTypes.includes(file.type)) {
+      setError('Formato de arquivo inválido. Apenas PNG, JPG ou PDF são permitidos.');
+      e.target.value = '';
+      return;
+    }
+    setError('');
+    // US004 does not define further processing in this page.
+  };
+
+  return (
+    <Layout>
+      <h2>Enviar Conta</h2>
+      <div className={styles.form}>
+        <input
+          type="file"
+          accept=".png,.jpg,.jpeg,.pdf"
+          onChange={handleFileChange}
+          ref={inputRef}
+          style={{ display: 'none' }}
+        />
+        <button type="button" onClick={handleButtonClick} className={styles.button}>
+          Selecionar Arquivo
+        </button>
+        {error && <div className={styles.error}>{error}</div>}
+      </div>
+    </Layout>
+  );
+};
 
 export default Upload;

--- a/styles/Upload.module.css
+++ b/styles/Upload.module.css
@@ -1,0 +1,18 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+
+.error {
+  background-color: #f8d7da;
+  color: #721c24;
+  padding: 0.75rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- create dedicated styles for upload page
- implement /upload page with file upload form
- validate PNG, JPG and PDF and display error on invalid files

## Testing
- `npm test`
- `npm run build` *(fails: `next` not found)*