### PR TITLE
Switch to gpt-4o model

### DIFF
--- a/pages/api/process.ts
+++ b/pages/api/process.ts
@@ -38,7 +38,7 @@ export default async function handler(
         Authorization: `Bearer ${key}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4-1106-vision-preview',
+        model: 'gpt-4o',
         messages: [
           {
             role: 'system',


### PR DESCRIPTION
## Summary
- use the new `gpt-4o` model in the API route

## Testing
- `npm test`