### PR TITLE
Improve success style for OpenAI key notice

### DIFF
--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -138,7 +138,9 @@ const Settings: NextPage = () => {
           <h3 className={styles.sectionTitle}>Configurações do OpenAI</h3>
           {keyStored ? (
             <>
-              <span className={styles.note}>Chave armazenada com segurança</span>
+              <div className={`${styles.message} ${styles.success}`}>
+                Chave armazenada com segurança
+              </div>
               <button onClick={deleteKey} className={styles.button}>
                 Remover chave
               </button>


### PR DESCRIPTION
## Summary
- display 'Chave armazenada com segurança' using the same success style as other messages

## Testing
- `npm test`