### PR TITLE
Show prompt and API response

### DIFF
--- a/pages/upload.tsx
+++ b/pages/upload.tsx
@@ -22,6 +22,8 @@ const Upload: NextPage = () => {
       codigoBarras: string;
     };
     confidence: number;
+    prompt: any;
+    raw: any;
   } | null>(null);
 
   const handleButtonClick = () => {
@@ -142,6 +144,12 @@ const Upload: NextPage = () => {
               </tr>
             </tbody>
           </table>
+          <div className={styles.debug}>
+            <h4>Prompt Enviado</h4>
+            <pre>{JSON.stringify(result.prompt, null, 2)}</pre>
+            <h4>Resposta Bruta da API</h4>
+            <pre>{JSON.stringify(result.raw, null, 2)}</pre>
+          </div>
         </div>
       )}
     </Layout>

--- a/styles/Upload.module.css
+++ b/styles/Upload.module.css
@@ -42,3 +42,13 @@
   border: 1px solid #ccc;
   padding: 0.5rem;
 }
+
+.debug {
+  margin-top: 1rem;
+  white-space: pre-wrap;
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 4px;
+  font-family: monospace;
+  overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- expose the messages sent to OpenAI and the raw API result in the `/api/process` response
- show the prompt and raw API response on the Upload page
- add debugging styles

## Testing
- `npm test`