### PR TITLE
Remove prompt and raw response from user view

### DIFF
--- a/pages/api/process.ts
+++ b/pages/api/process.ts
@@ -12,8 +12,6 @@ interface Fields {
 interface ProcessResponse {
   fields: Fields;
   confidence: number;
-  prompt: any;
-  raw: any;
 }
 
 export default async function handler(
@@ -102,8 +100,6 @@ export default async function handler(
           codigoBarras: '',
         },
         confidence: 0,
-        prompt: messages,
-        raw: result,
       });
       return;
     }
@@ -124,7 +120,7 @@ export default async function handler(
         ? parsed.confidence
         : filled / keys.length;
 
-    res.status(200).json({ fields, confidence, prompt: messages, raw: result });
+    res.status(200).json({ fields, confidence });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     res.status(500).json({ error: message });

--- a/pages/upload.tsx
+++ b/pages/upload.tsx
@@ -22,8 +22,6 @@ const Upload: NextPage = () => {
       codigoBarras: string;
     };
     confidence: number;
-    prompt: any;
-    raw: any;
   } | null>(null);
 
   const handleButtonClick = () => {
@@ -144,12 +142,6 @@ const Upload: NextPage = () => {
               </tr>
             </tbody>
           </table>
-          <div className={styles.debug}>
-            <h4>Prompt Enviado</h4>
-            <pre>{JSON.stringify(result.prompt, null, 2)}</pre>
-            <h4>Resposta Bruta da API</h4>
-            <pre>{JSON.stringify(result.raw, null, 2)}</pre>
-          </div>
         </div>
       )}
     </Layout>

--- a/styles/Upload.module.css
+++ b/styles/Upload.module.css
@@ -43,12 +43,3 @@
   padding: 0.5rem;
 }
 
-.debug {
-  margin-top: 1rem;
-  white-space: pre-wrap;
-  background: #f5f5f5;
-  padding: 1rem;
-  border-radius: 4px;
-  font-family: monospace;
-  overflow-x: auto;
-}


### PR DESCRIPTION
## Summary
- hide debug info on the Upload page
- stop returning `prompt` and `raw` fields from the process API

## Testing
- `npm test`