### PR TITLE
Implement send to spreadsheet feature

### DIFF
--- a/pages/api/config.ts
+++ b/pages/api/config.ts
@@ -4,7 +4,15 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     const hasGoogleToken = Boolean(req.cookies.googleToken);
     const hasOpenAIKey = Boolean(req.cookies.openaiKey);
-    res.status(200).json({ hasGoogleToken, hasOpenAIKey });
+    const sheetName =
+      req.cookies.sheetName || 'Agent Bill - Controle de Contas';
+    const sheetId = req.cookies.sheetId || '';
+    res.status(200).json({
+      hasGoogleToken,
+      hasOpenAIKey,
+      sheetName,
+      sheetId,
+    });
     return;
   }
 
@@ -15,6 +23,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     }
     if (req.body.openaiKey) {
       cookies.push(`openaiKey=${req.body.openaiKey}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`);
+    }
+    if (req.body.sheetName) {
+      cookies.push(`sheetName=${encodeURIComponent(req.body.sheetName)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`);
+    }
+    if (req.body.sheetId) {
+      cookies.push(`sheetId=${req.body.sheetId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`);
     }
     if (cookies.length) {
       res.setHeader('Set-Cookie', cookies);
@@ -30,6 +44,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     }
     if (req.query.key === 'openai' || !req.query.key) {
       cookies.push('openaiKey=; Path=/; HttpOnly; Max-Age=0; SameSite=Lax');
+    }
+    if (req.query.key === 'sheet' || !req.query.key) {
+      cookies.push('sheetId=; Path=/; HttpOnly; Max-Age=0; SameSite=Lax');
+    }
+    if (req.query.key === 'sheetName') {
+      cookies.push('sheetName=; Path=/; HttpOnly; Max-Age=0; SameSite=Lax');
     }
     if (cookies.length) {
       res.setHeader('Set-Cookie', cookies);

--- a/pages/api/sheets.ts
+++ b/pages/api/sheets.ts
@@ -1,0 +1,113 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface Fields {
+  empresaRecebedora: string;
+  pagador: string;
+  tipo: string;
+  valor: string;
+  vencimento: string;
+  codigoBarras: string;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  const token = req.cookies.googleToken;
+  if (!token) {
+    res.status(401).json({ error: 'Not authenticated with Google' });
+    return;
+  }
+
+  const fields = req.body as Fields;
+  const sheetName = req.cookies.sheetName || 'Agent Bill - Controle de Contas';
+  let sheetId = req.cookies.sheetId;
+
+  try {
+    if (!sheetId) {
+      // create spreadsheet
+      const createRes = await fetch('https://sheets.googleapis.com/v4/spreadsheets', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ properties: { title: sheetName } }),
+      });
+      if (!createRes.ok) {
+        const text = await createRes.text();
+        res.status(500).json({ error: `Failed to create spreadsheet: ${text}` });
+        return;
+      }
+      const createData = await createRes.json();
+      sheetId = createData.spreadsheetId;
+      // store sheetId cookie
+      res.setHeader('Set-Cookie', `sheetId=${sheetId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`);
+
+      // write header row
+      const headerRes = await fetch(
+        `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/Sheet1!A1:F1?valueInputOption=RAW`,
+        {
+          method: 'PUT',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            values: [
+              [
+                'Empresa Recebedora',
+                'Pagador',
+                'Tipo',
+                'Valor',
+                'Vencimento',
+                'Código de Barras',
+              ],
+            ],
+          }),
+        },
+      );
+      if (!headerRes.ok) {
+        const text = await headerRes.text();
+        res.status(500).json({ error: `Failed to write headers: ${text}` });
+        return;
+      }
+    }
+
+    // append new row
+    const appendRes = await fetch(
+      `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/Sheet1!A:F:append?valueInputOption=USER_ENTERED`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          values: [[
+            fields.empresaRecebedora,
+            fields.pagador,
+            fields.tipo,
+            fields.valor,
+            fields.vencimento,
+            fields.codigoBarras,
+          ]],
+        }),
+      },
+    );
+
+    if (!appendRes.ok) {
+      const text = await appendRes.text();
+      res.status(500).json({ error: `Failed to append row: ${text}` });
+      return;
+    }
+
+    const appendData = await appendRes.json();
+    res.status(200).json({ updatedRange: appendData.updates?.updatedRange, sheetId });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ error: message });
+  }
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -15,6 +15,7 @@ const Settings: NextPage = () => {
   const [userEmail, setUserEmail] = useState('');
   const [userIcon, setUserIcon] = useState('');
   const [userName, setUserName] = useState('');
+  const [sheetName, setSheetName] = useState('Agent Bill - Controle de Contas');
 
   useEffect(() => {
     fetch('/api/config')
@@ -22,6 +23,7 @@ const Settings: NextPage = () => {
       .then((data) => {
         setConnected(data.hasGoogleToken);
         setKeyStored(data.hasOpenAIKey);
+        if (data.sheetName) setSheetName(data.sheetName);
       });
   }, []);
 
@@ -121,6 +123,17 @@ const Settings: NextPage = () => {
     });
   };
 
+  const saveSheet = () => {
+    fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sheetName }),
+    }).then(() => {
+      setMessage('Nome da planilha salvo!');
+      setIsError(false);
+    });
+  };
+
   return (
     <Layout>
       <h2>Configurações</h2>
@@ -196,6 +209,17 @@ const Settings: NextPage = () => {
               Conectar Google
             </button>
           )}
+          <label htmlFor="sheetName">Nome da planilha:</label>
+          <input
+            id="sheetName"
+            type="text"
+            value={sheetName}
+            onChange={(e) => setSheetName(e.target.value)}
+            className={styles.input}
+          />
+          <button onClick={saveSheet} className={styles.button}>
+            Salvar nome
+          </button>
         </div>
       </div>
     </Layout>

--- a/pages/spreadsheet.tsx
+++ b/pages/spreadsheet.tsx
@@ -1,11 +1,40 @@
 import type { NextPage } from 'next';
+import { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
 
-const Spreadsheet: NextPage = () => (
-  <Layout>
-    <h2>Planilha</h2>
-    <p>Esta página exibirá seus dados do Google Sheets.</p>
-  </Layout>
-);
+const Spreadsheet: NextPage = () => {
+  const [sheetId, setSheetId] = useState('');
+  const [sheetName, setSheetName] = useState('Agent Bill - Controle de Contas');
+
+  useEffect(() => {
+    fetch('/api/config')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.sheetId) setSheetId(data.sheetId);
+        if (data.sheetName) setSheetName(data.sheetName);
+      });
+  }, []);
+
+  return (
+    <Layout>
+      <h2>Planilha</h2>
+      {sheetId ? (
+        <p>
+          Acesse sua planilha{' '}
+          <a
+            href={`https://docs.google.com/spreadsheets/d/${sheetId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {sheetName}
+          </a>
+          .
+        </p>
+      ) : (
+        <p>Planilha ainda não criada. Envie uma conta para gerar a planilha.</p>
+      )}
+    </Layout>
+  );
+};
 
 export default Spreadsheet;

--- a/pages/upload.tsx
+++ b/pages/upload.tsx
@@ -26,6 +26,7 @@ const Upload: NextPage = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState('');
   const [status, setStatus] = useState('');
+  const [sheetStatus, setSheetStatus] = useState('');
   const [result, setResult] = useState<{
     fields: {
       empresaRecebedora: string;
@@ -100,6 +101,28 @@ const Upload: NextPage = () => {
     }
   };
 
+  const sendToSheet = async () => {
+    if (!result) return;
+    setSheetStatus('Enviando para a planilha...');
+    const res = await fetch('/api/sheets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(result.fields),
+    });
+    if (res.ok) {
+      setSheetStatus('Conta adicionada à planilha!');
+    } else {
+      const text = await res.text();
+      let msg = text;
+      try {
+        msg = JSON.parse(text).error || text;
+      } catch {
+        // ignore
+      }
+      setSheetStatus(`Erro ao adicionar: ${msg}`);
+    }
+  };
+
   return (
     <Layout>
       <h2>Enviar Conta</h2>
@@ -157,9 +180,10 @@ const Upload: NextPage = () => {
             </tbody>
           </table>
           <div className={styles.actions}>
-            <button type="button" className={styles.button}>
+            <button type="button" className={styles.button} onClick={sendToSheet}>
               Adicione à planilha
             </button>
+            {sheetStatus && <div className={styles.status}>{sheetStatus}</div>}
             <button type="button" className={styles.button}>
               Adicione ao seu calendario
             </button>


### PR DESCRIPTION
## Summary
- store Google Sheets info via API config
- create new `/api/sheets` endpoint to create spreadsheet and append rows
- allow configuring spreadsheet name in Settings
- link to created spreadsheet on Spreadsheet page
- hook up "Adicione à planilha" button on Upload page

## Testing
- `npm run build` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: missing type declarations)*