### PR TITLE
Fix openAI key banner text

### DIFF
--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -153,7 +153,7 @@ const Settings: NextPage = () => {
     <Layout>
       <h2>Configurações</h2>
       {keyStored && (
-        <div className={`${styles.message} ${styles.success}`}>Chave armazenada com segurança!</div>
+        <div className={`${styles.message} ${styles.success}`}>Chave configurada e armazenada!</div>
       )}
       {message && (
         <div className={`${styles.message} ${isError ? styles.error : styles.success}`}>{message}


### PR DESCRIPTION
## Summary
- restore settings banner text for stored openAI key

## Testing
- `npm test`
- `npm run build` *(fails: next not installed)*