### PR TITLE
Display logo on all pages

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -10,7 +10,10 @@ export default function Layout({ children }: Props) {
   return (
     <div className={styles.container}>
       <header className={styles.header}>
-        <h1 className={styles.title}>Agent Bill</h1>
+        <div className={styles.branding}>
+          <img src="/AgentBillLogo.png" alt="Agent Bill logo" className={styles.logo} />
+          <h1 className={styles.title}>Agent Bill</h1>
+        </div>
         <nav className={styles.nav}>
           <Link href="/">Início</Link>
           <Link href="/upload">Enviar Conta</Link>

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -43,3 +43,15 @@
   padding: 1rem;
   text-align: center;
 }
+
+/* Container for logo and title inside the header */
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.logo {
+  height: 40px;
+  width: auto;
+}


### PR DESCRIPTION
## Summary
- add header branding styles
- show logo inside the layout header

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*