### PR TITLE
Center logo below header on all pages

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -10,10 +10,6 @@ export default function Layout({ children }: Props) {
   return (
     <div className={styles.container}>
       <header className={styles.header}>
-        <div className={styles.branding}>
-          <img src="/AgentBillLogo.png" alt="Agent Bill logo" className={styles.logo} />
-          <h1 className={styles.title}>Agent Bill</h1>
-        </div>
         <nav className={styles.nav}>
           <Link href="/">Início</Link>
           <Link href="/upload">Enviar Conta</Link>
@@ -21,6 +17,9 @@ export default function Layout({ children }: Props) {
           <Link href="/settings">Configurações</Link>
         </nav>
       </header>
+      <div className={styles.logoContainer}>
+        <img src="/AgentBillLogo.png" alt="Agent Bill logo" className={styles.logo} />
+      </div>
       <main className={styles.main}>{children}</main>
       <footer className={styles.footer}>
         <Link href="/privacy">Política de Privacidade</Link> |{' '}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,10 +6,6 @@ import styles from '../styles/Home.module.css';
 const Home: NextPage = () => {
   return (
     <Layout>
-      <div className={styles.logoContainer}>
-        {/* Display project logo */}
-        <img src="/AgentBillLogo.png" alt="Agent Bill logo" className={styles.logo} />
-      </div>
       <div className={styles.grid}>
         <Link href="/upload" className={styles.card}>
           <h2>Enviar Conta &rarr;</h2>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -4,15 +4,6 @@
   gap: 1.5rem;
 }
 
-.logoContainer {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.logo {
-  max-width: 200px;
-  height: auto;
-}
 
 .card {
   padding: 1.5rem;

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -9,14 +9,10 @@
   padding: 1rem;
   color: white;
   display: flex;
+  justify-content: center;
   align-items: center;
-  justify-content: space-between;
 }
 
-.title {
-  margin: 0;
-  font-size: 1.5rem;
-}
 
 .nav {
   display: flex;
@@ -44,14 +40,12 @@
   text-align: center;
 }
 
-/* Container for logo and title inside the header */
-.branding {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+.logoContainer {
+  text-align: center;
+  margin: 1rem 0;
 }
 
 .logo {
-  height: 40px;
-  width: auto;
+  max-width: 200px;
+  height: auto;
 }


### PR DESCRIPTION
## Summary
- move logo out of the navigation bar
- center logo below the header globally
- clean up homepage and unused CSS

## Testing
- `npm test`
- `npm run build` *(fails: `next` not found)*