### PR TITLE
Add external links page

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -13,7 +13,7 @@ export default function Layout({ children }: Props) {
         <nav className={styles.nav}>
           <Link href="/">Início</Link>
           <Link href="/upload">Enviar Conta</Link>
-          <Link href="/spreadsheet">Planilha</Link>
+          <Link href="/links">Links externos</Link>
           <Link href="/settings">Configurações</Link>
         </nav>
       </header>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,9 +11,9 @@ const Home: NextPage = () => {
           <h2>Enviar Conta &rarr;</h2>
           <p>Envie uma imagem ou PDF para processamento.</p>
         </Link>
-        <Link href="/spreadsheet" className={styles.card}>
-          <h2>Planilha &rarr;</h2>
-          <p>Veja todas as suas contas no Google Sheets.</p>
+        <Link href="/links" className={styles.card}>
+          <h2>Links externos &rarr;</h2>
+          <p>Acesse a planilha e seu calendário.</p>
         </Link>
         <Link href="/settings" className={styles.card}>
           <h2>Configurações &rarr;</h2>

--- a/pages/links.tsx
+++ b/pages/links.tsx
@@ -2,7 +2,7 @@ import type { NextPage } from 'next';
 import { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
 
-const Spreadsheet: NextPage = () => {
+const Links: NextPage = () => {
   const [sheetId, setSheetId] = useState('');
   const [sheetName, setSheetName] = useState('Agent Bill - Controle de Contas');
 
@@ -17,10 +17,10 @@ const Spreadsheet: NextPage = () => {
 
   return (
     <Layout>
-      <h2>Planilha</h2>
+      <h2>Links externos</h2>
       {sheetId ? (
         <p>
-          Acesse sua planilha{' '}
+          A planilha a seguir contém todas as contas que você enviou:{' '}
           <a
             href={`https://docs.google.com/spreadsheets/d/${sheetId}`}
             target="_blank"
@@ -33,8 +33,19 @@ const Spreadsheet: NextPage = () => {
       ) : (
         <p>Planilha ainda não criada. Envie uma conta para gerar a planilha.</p>
       )}
+      <p>
+        Consulte seu calendário no{' '}
+        <a
+          href="https://calendar.google.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Calendar
+        </a>{' '}
+        para acompanhar seus lembretes.
+      </p>
     </Layout>
   );
 };
 
-export default Spreadsheet;
+export default Links;


### PR DESCRIPTION
## Summary
- rename Planilha page to Links externos
- link the new page in navigation
- update home page card text
- include link to Google Calendar along with the spreadsheet link

## Testing
- `npm test`