### PR TITLE
Fix Drive trashed sheet detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The application ships with a built-in Google OAuth client ID so it runs out of
 the box. If you prefer to use your own ID, update the `GOOGLE_CLIENT_ID`
 constant in `pages/settings.tsx`. The redirect URL should point to
 `/oauth2callback` on your deployed site. Once configured, you can connect or
-disconnect your Google account from the **Settings** page.
+disconnect your Google account from the **Settings** page. When connecting, the application requests access to Calendar, Sheets, Drive metadata and your basic profile so it can detect when a spreadsheet is moved to the trash.
 
 ## Secure Configuration Storage
 

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -83,7 +83,7 @@ const Settings: NextPage = () => {
       redirect_uri: `${window.location.origin}/oauth2callback`,
       response_type: 'token',
       scope:
-        'https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile',
+        'https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile',
       include_granted_scopes: 'true',
     });
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;


### PR DESCRIPTION
## Summary
- request Google Drive metadata scope during OAuth sign-in
- document that Drive access is requested so the app can detect trashed sheets

## Testing
- `npm test`