### PR TITLE
Fix underline on main menu links

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -36,7 +36,9 @@ export default function Layout({ children }: Props) {
     return disable ? (
       <span className={styles.disabled}>{label}</span>
     ) : (
-      <Link href={href}>{label}</Link>
+      <Link href={href} className={styles.navLink}>
+        {label}
+      </Link>
     );
   };
 
@@ -47,7 +49,9 @@ export default function Layout({ children }: Props) {
           {renderLink('/', 'Início', !configured)}
           {renderLink('/upload', 'Enviar Conta', !configured)}
           {renderLink('/links', 'Links externos', !configured)}
-          <Link href="/settings">Configurações</Link>
+          <Link href="/settings" className={styles.navLink}>
+            Configurações
+          </Link>
         </nav>
       </header>
       <div className={styles.logoContainer}>

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -19,10 +19,11 @@
   gap: 1rem;
 }
 
-.nav a {
+.navLink {
   color: #ecf0f1;
+  font-weight: bold;
   transition: color 0.2s ease;
-  text-decoration: none;
+  text-decoration: none !important;
 }
 
 .disabled {
@@ -31,9 +32,8 @@
   cursor: default;
 }
 
-.nav a:hover {
+.navLink:hover {
   color: #ffffff;
-  text-decoration: underline;
 }
 
 .main {


### PR DESCRIPTION
## Summary
- keep external link style with underline in Links page
- add `navLink` class for menu buttons to remove underline and bolden text

## Testing
- `npm test`