### PR TITLE
Reapply spreadsheet header formatting

### DIFF
--- a/docs/spreadsheet_formatting.md
+++ b/docs/spreadsheet_formatting.md
@@ -2,11 +2,10 @@
 
 These guidelines explain how the Google Sheet **Agent Bill -- Controle de Contas** should be formatted.
 
-## Adding the Agent Bill logo
-1. Merge the cells `A1:F6` on the `Contas` sheet.
-2. Insert the same logo used by the application inside the merged cell. The application logo is available in the repository at `public/AgentBillLogo.png`.
-3. Use the formula `=IMAGE("https://<YOUR_APP_URL>/AgentBillLogo.png")` or embed the image directly so it spans rows 1–6.
-4. Center the image horizontally and keep its aspect ratio when resizing.
+## Adding the Agent Bill title
+1. In cell `A1` of the `Contas` sheet enter the text **Agent Bill**.
+2. Set the font size to **40** and make it **bold**.
+3. Do not merge any cells when adding the title.
 
 ## Formatting the header row
 When the first bill is inserted the header row should be styled for readability:


### PR DESCRIPTION
## Summary
- restore Agent Bill title instructions in spreadsheet docs
- reapply header styling when inserting the first bill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683af33e0cdc832ea40952b2f8ef532c