### PR TITLE
Add refresh token support for Google OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=198927534674-0akhqu4ip9hg276ag2mliknkh7pvp4op.apps.googleusercontent.com
+GOOGLE_CLIENT_ID=your_client_id
+GOOGLE_CLIENT_SECRET=your_client_secret
+GOOGLE_REDIRECT_URI=http://localhost:3000/oauth2callback
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ own credentials:
 cp .env.example .env.local
 ```
 
+Make sure to fill in `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` and
+`GOOGLE_REDIRECT_URI` in `.env.local` so the server can refresh expired tokens
+automatically.
+
 
 The application ships with a built-in Google OAuth client ID so it runs out of
 the box. If you prefer to use your own ID, update the `GOOGLE_CLIENT_ID`

--- a/docs/folder_structure.md
+++ b/docs/folder_structure.md
@@ -109,4 +109,5 @@ Static files served from `/`.
 |------|-------------|
 | `utils/image.ts` | Helper functions to read and compress images. |
 | `utils/logoData.ts` | Base64 encoded logo data. **Deprecated** |
+| `utils/googleAuth.ts` | Helpers to exchange and refresh Google OAuth tokens. |
 

--- a/docs/setup_google.md
+++ b/docs/setup_google.md
@@ -20,6 +20,7 @@ O AgentBill já possui um ID de exemplo, mas você pode substituir pelo seu pró
 2. Localize a constante `GOOGLE_CLIENT_ID` perto do início do componente.
 3. Substitua o valor existente pelo ID obtido na etapa anterior.
 4. Opcionalmente, crie um arquivo `.env.local` a partir de `.env.example` e mantenha o mesmo ID para facilitar a configuração local.
+5. No mesmo arquivo `.env.local`, defina `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` e `GOOGLE_REDIRECT_URI` com os valores do seu projeto. Esses dados permitem que o backend troque o código de autorização por tokens de acesso e atualização.
 
 ## 3. Ativar a API de Sheets
 

--- a/pages/api/calendar.ts
+++ b/pages/api/calendar.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getValidAccessToken } from '../../utils/googleAuth';
 
 interface Fields {
   empresaRecebedora: string;
@@ -15,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const token = req.cookies.googleToken;
+  const token = await getValidAccessToken(req, res);
   if (!token) {
     res.status(401).json({ error: 'Not authenticated with Google' });
     return;

--- a/pages/api/googleAuth.ts
+++ b/pages/api/googleAuth.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { exchangeCode } from '../../utils/googleAuth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  const { code } = req.body as { code?: string };
+  if (!code) {
+    res.status(400).json({ error: 'Missing authorization code' });
+    return;
+  }
+
+  try {
+    const data = await exchangeCode(code);
+    const cookies: string[] = [];
+    if (data.access_token) {
+      cookies.push(
+        `googleToken=${data.access_token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
+      );
+    }
+    if (data.refresh_token) {
+      cookies.push(
+        `googleRefreshToken=${data.refresh_token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
+      );
+    }
+    if (data.expires_in) {
+      cookies.push(
+        `googleTokenExpires=${Date.now() + data.expires_in * 1000}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
+      );
+    }
+    if (cookies.length) {
+      res.setHeader('Set-Cookie', cookies);
+    }
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ error: message });
+  }
+}

--- a/pages/api/renameSheet.ts
+++ b/pages/api/renameSheet.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getValidAccessToken } from '../../utils/googleAuth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -6,7 +7,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const token = req.cookies.googleToken;
+  const token = await getValidAccessToken(req, res);
   const { sheetId, sheetName } = req.body;
   if (!token) {
     res.status(401).json({ error: 'Not authenticated with Google' });

--- a/pages/api/sheets.ts
+++ b/pages/api/sheets.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getValidAccessToken } from '../../utils/googleAuth';
 
 interface Fields {
   empresaRecebedora: string;
@@ -15,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const token = req.cookies.googleToken;
+  const token = await getValidAccessToken(req, res);
   if (!token) {
     res.status(401).json({ error: 'Not authenticated with Google' });
     return;

--- a/pages/api/userinfo.ts
+++ b/pages/api/userinfo.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getValidAccessToken } from '../../utils/googleAuth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const token = req.cookies.googleToken;
+  const token = await getValidAccessToken(req, res);
   if (!token) {
     res.status(401).json({ error: 'Not connected' });
     return;

--- a/pages/oauth2callback.tsx
+++ b/pages/oauth2callback.tsx
@@ -7,15 +7,15 @@ export default function OAuthCallback() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const hash = window.location.hash.substring(1);
-      const params = new URLSearchParams(hash);
-      const token = params.get('access_token');
-      if (token) {
-        fetch('/api/config', {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      if (code) {
+        fetch('/api/googleAuth', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ googleToken: token }),
+          body: JSON.stringify({ code }),
         })
+          .then((r) => (r.ok ? r.json() : Promise.reject()))
           .then(() => {
             window.dispatchEvent(new Event('config-changed'));
             router.replace('/settings?status=success');

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -84,7 +84,9 @@ const Settings: NextPage = () => {
     const params = new URLSearchParams({
       client_id: clientId,
       redirect_uri: `${window.location.origin}/oauth2callback`,
-      response_type: 'token',
+      response_type: 'code',
+      access_type: 'offline',
+      prompt: 'consent',
       scope:
         'https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile',
       include_granted_scopes: 'true',

--- a/utils/googleAuth.ts
+++ b/utils/googleAuth.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const CLIENT_ID = process.env.GOOGLE_CLIENT_ID || process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || '';
+const CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || '';
+const REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || '';
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
+}
+
+export async function exchangeCode(code: string): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    code,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    redirect_uri: REDIRECT_URI,
+    grant_type: 'authorization_code',
+  });
+
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+
+  return res.json() as Promise<TokenResponse>;
+}
+
+export async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    refresh_token: refreshToken,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    grant_type: 'refresh_token',
+  });
+
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+
+  return res.json() as Promise<TokenResponse>;
+}
+
+export async function getValidAccessToken(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<string | null> {
+  let token = req.cookies.googleToken;
+  const refreshToken = req.cookies.googleRefreshToken;
+  const expires = req.cookies.googleTokenExpires;
+
+  if (!token) return null;
+
+  const expiry = expires ? parseInt(expires, 10) : 0;
+  if (Date.now() >= expiry - 60000) {
+    if (!refreshToken) return null;
+    try {
+      const data = await refreshAccessToken(refreshToken);
+      token = data.access_token;
+      const cookies: string[] = [
+        `googleToken=${token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
+        `googleTokenExpires=${Date.now() + data.expires_in * 1000}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
+      ];
+      if (data.refresh_token) {
+        cookies.push(`googleRefreshToken=${data.refresh_token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`);
+      }
+      res.setHeader('Set-Cookie', cookies);
+    } catch (err) {
+      console.error('Failed to refresh Google token', err);
+      return null;
+    }
+  }
+
+  return token;
+}


### PR DESCRIPTION
## Summary
- refresh Google tokens automatically
- add OAuth helper utilities and API endpoint
- use code-based OAuth flow with refresh token
- document new environment variables

## Testing
- `npm test`
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b2bd60938832eb8ef5475dd85a2a2