### PR TITLE
Fix Google OAuth error display

### DIFF
--- a/pages/oauth2callback.tsx
+++ b/pages/oauth2callback.tsx
@@ -15,12 +15,22 @@ export default function OAuthCallback() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ code }),
         })
-          .then((r) => (r.ok ? r.json() : Promise.reject()))
+          .then(async (r) => {
+            if (r.ok) return r.json();
+            const text = await r.text();
+            return Promise.reject(new Error(text));
+          })
           .then(() => {
             window.dispatchEvent(new Event('config-changed'));
             router.replace('/settings?status=success');
           })
-          .catch(() => router.replace('/settings?status=error'));
+          .catch((err) =>
+            router.replace(
+              `/settings?status=error&message=${encodeURIComponent(
+                err instanceof Error ? err.message : String(err),
+              )}`,
+            ),
+          );
       } else {
         router.replace('/settings?status=error');
       }

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -60,13 +60,17 @@ const Settings: NextPage = () => {
       setIsError(false);
       setShowRetry(false);
     } else if (router.query.status === 'error') {
-      setMessage('Falha ao autenticar com o Google. Certifique-se de conceder acesso e tente novamente.');
+      const errMsg =
+        typeof router.query.message === 'string' && router.query.message
+          ? router.query.message
+          : 'Falha ao autenticar com o Google. Certifique-se de conceder acesso e tente novamente.';
+      setMessage(errMsg);
       setIsError(true);
       setShowRetry(true);
     } else {
       setShowRetry(false);
     }
-  }, [router.query.status]);
+  }, [router.query.status, router.query.message]);
 
 
   // Hard-coded default Google OAuth client ID so the app works without config


### PR DESCRIPTION
## Summary
- surface error messages from the Google auth callback
- display detailed auth errors on the Settings page

## Testing
- `npm test` *(fails: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_b_683b30b2c71c832e80e459316454b39b