### PR TITLE
Fix redirect_uri handling for Google OAuth

### DIFF
--- a/pages/api/googleAuth.ts
+++ b/pages/api/googleAuth.ts
@@ -7,14 +7,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const { code } = req.body as { code?: string };
+  const { code, redirect_uri } = req.body as {
+    code?: string;
+    redirect_uri?: string;
+  };
   if (!code) {
     res.status(400).json({ error: 'Missing authorization code' });
     return;
   }
 
   try {
-    const data = await exchangeCode(code);
+    const data = await exchangeCode(code, redirect_uri);
     const cookies: string[] = [];
     if (data.access_token) {
       cookies.push(

--- a/pages/oauth2callback.tsx
+++ b/pages/oauth2callback.tsx
@@ -13,7 +13,10 @@ export default function OAuthCallback() {
         fetch('/api/googleAuth', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ code }),
+          body: JSON.stringify({
+            code,
+            redirect_uri: `${window.location.origin}/oauth2callback`,
+          }),
         })
           .then(async (r) => {
             if (r.ok) return r.json();

--- a/utils/googleAuth.ts
+++ b/utils/googleAuth.ts
@@ -13,7 +13,7 @@ const CLIENT_ID =
   process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ||
   '198927534674-0akhqu4ip9hg276ag2mliknkh7pvp4op.apps.googleusercontent.com';
 const CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || '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';
-const REDIRECT_URI =
+const DEFAULT_REDIRECT_URI =
   process.env.GOOGLE_REDIRECT_URI || 'https://agent-bill.vercel.app/oauth2callback';
 
 interface TokenResponse {
@@ -22,12 +22,15 @@ interface TokenResponse {
   refresh_token?: string;
 }
 
-export async function exchangeCode(code: string): Promise<TokenResponse> {
+export async function exchangeCode(
+  code: string,
+  redirect_uri: string = DEFAULT_REDIRECT_URI,
+): Promise<TokenResponse> {
   const params = new URLSearchParams({
     code,
     client_id: CLIENT_ID,
     client_secret: CLIENT_SECRET,
-    redirect_uri: REDIRECT_URI,
+    redirect_uri,
     grant_type: 'authorization_code',
   });
 


### PR DESCRIPTION
## Summary
- accept `redirect_uri` from the OAuth callback page
- forward `redirect_uri` to the server when exchanging the authorization code
- default to `GOOGLE_REDIRECT_URI` when none provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b63dba54c832eb3c12767a35695bf