### PR TITLE
Embed sheet on links page

### DIFF
--- a/pages/links.tsx
+++ b/pages/links.tsx
@@ -20,22 +20,29 @@ const Links: NextPage = () => {
     <Layout>
       <h2>Links externos</h2>
       {sheetId ? (
-        <p>
-          A planilha a seguir contém todas as contas que você enviou:{' '}
-          <button
-            onClick={() =>
-              window.open(
-                `https://docs.google.com/spreadsheets/d/${sheetId}`,
-                '_blank',
-                'noopener,noreferrer'
-              )
-            }
-            className={styles.button}
-          >
-            {sheetName}
-          </button>
-          .
-        </p>
+        <>
+          <iframe
+            src={`https://docs.google.com/spreadsheets/d/${sheetId}/preview`}
+            className={styles.iframe}
+            title="Planilha"
+          />
+          <p>
+            A planilha a seguir contém todas as contas que você enviou:{' '}
+            <button
+              onClick={() =>
+                window.open(
+                  `https://docs.google.com/spreadsheets/d/${sheetId}`,
+                  '_blank',
+                  'noopener,noreferrer'
+                )
+              }
+              className={styles.button}
+            >
+              {sheetName}
+            </button>
+            .
+          </p>
+        </>
       ) : (
         <p>Planilha ainda não criada. Envie uma conta para gerar a planilha.</p>
       )}

--- a/styles/Links.module.css
+++ b/styles/Links.module.css
@@ -3,3 +3,10 @@
   font-size: 1rem;
   margin: 0.5rem 0;
 }
+
+.iframe {
+  width: 100%;
+  height: 600px;
+  border: none;
+  margin: 1rem 0;
+}


### PR DESCRIPTION
## Summary
- embed Google Sheet directly on Links page
- keep existing buttons below embedded sheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683bb279eee0832e8676a6b9d641a464