### PR TITLE
Rename Links page to Planilha

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -48,7 +48,7 @@ export default function Layout({ children }: Props) {
         <nav className={styles.nav}>
           {renderLink('/', 'Início', !configured)}
           {renderLink('/upload', 'Enviar Conta', !configured)}
-          {renderLink('/links', 'Links externos', !configured)}
+          {renderLink('/links', 'Planilha', !configured)}
           <Link href="/settings" className={styles.navLink}>
             Configurações
           </Link>

--- a/docs/folder_structure.md
+++ b/docs/folder_structure.md
@@ -57,7 +57,7 @@ This document summarizes the folder layout of **AgentBill** and describes the pu
 |------|-------------|
 | `pages/_app.tsx` | Custom App component that sets global metadata. |
 | `pages/index.tsx` | Home page with links to main features. |
-| `pages/links.tsx` | Shows links to the Google Sheet and Calendar. |
+| `pages/links.tsx` | Displays the Planilha page with access to the Google Sheet and Calendar. |
 | `pages/settings.tsx` | Manage Google OAuth and OpenAI key. |
 | `pages/upload.tsx` | Upload page for bills. |
 | `pages/oauth2callback.tsx` | Handles Google OAuth redirect. |
@@ -98,7 +98,7 @@ Static files served from `/`.
 |------|-------------|
 | `styles/globals.css` | Global styles loaded by `_app.tsx`. |
 | `styles/Home.module.css` | Styles for the home page. |
-| `styles/Links.module.css` | Styles for the links page. |
+| `styles/Links.module.css` | Styles for the Planilha page. |
 | `styles/Layout.module.css` | Styles for the layout component. |
 | `styles/Settings.module.css` | Styles for the settings page. |
 | `styles/Upload.module.css` | Styles for the upload page. |

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,12 +32,12 @@ const Home: NextPage = () => {
         )}
         {configured ? (
           <Link href="/links" className={styles.card}>
-            <h2>Links externos &rarr;</h2>
+            <h2>Planilha &rarr;</h2>
             <p>Acesse a planilha e seu calendário.</p>
           </Link>
         ) : (
           <span className={`${styles.card} ${styles.disabled}`}>
-            <h2>Links externos &rarr;</h2>
+            <h2>Planilha &rarr;</h2>
             <p>Acesse a planilha e seu calendário.</p>
           </span>
         )}

--- a/pages/links.tsx
+++ b/pages/links.tsx
@@ -18,7 +18,7 @@ const Links: NextPage = () => {
 
   return (
     <Layout>
-      <h2>Links externos</h2>
+      <h2>Planilha</h2>
       <h3>Visualização da Planilha de Contas</h3>
       {sheetId ? (
         <>


### PR DESCRIPTION
## Summary
- rename "Links externos" page back to "Planilha"
- update navigation labels and home page button
- update page heading
- document Planilha page in folder structure docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683bb5ec5b34832e807c93b9d4878232