### PR TITLE
Highlight active menu item

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -70,10 +70,17 @@ export default function Layout({ children }: Props) {
     label: string,
     disable: boolean
   ) => {
-    return disable ? (
-      <span className={styles.disabled}>{label}</span>
-    ) : (
-      <Link href={href} className={styles.navLink}>
+    if (disable) {
+      return <span className={styles.disabled}>{label}</span>;
+    }
+
+    const linkClass =
+      router.pathname === href
+        ? `${styles.navLink} ${styles.active}`
+        : styles.navLink;
+
+    return (
+      <Link href={href} className={linkClass}>
         {label}
       </Link>
     );
@@ -86,7 +93,14 @@ export default function Layout({ children }: Props) {
           {renderLink('/', 'Início', !configured)}
           {renderLink('/upload', 'Enviar Conta', !configured)}
           {renderLink('/links', 'Planilha', !configured)}
-          <Link href="/settings" className={styles.navLink}>
+          <Link
+            href="/settings"
+            className={
+              router.pathname === '/settings'
+                ? `${styles.navLink} ${styles.active}`
+                : styles.navLink
+            }
+          >
             Configurações
           </Link>
         </nav>

--- a/styles/Layout.module.css
+++ b/styles/Layout.module.css
@@ -21,9 +21,12 @@
 
 .navLink {
   color: #ecf0f1;
-  font-weight: bold;
   transition: color 0.2s ease;
   text-decoration: none !important;
+}
+
+.active {
+  font-weight: bold;
 }
 
 .disabled {


### PR DESCRIPTION
## Summary
- show which page is active in the navigation bar by adding an `active` class
- apply active style when a page is selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683bbe974304832e8b7169b40be6451b