### PR TITLE
Add WhatsApp user stories link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For more details about how the project integrates with Google services and OpenA
 ## Documentation
 
 High level user stories and requirements are stored in the [docs/user_stories.md](docs/user_stories.md) file. Detailed descriptions can be found in [docs/detailed_user_stories.md](docs/detailed_user_stories.md).
+Specific user stories for the WhatsApp ordering flow are documented in [docs/whatsapp_user_stories.md](docs/whatsapp_user_stories.md).
 Formatting guidelines are available in [docs/spreadsheet_formatting.md](docs/spreadsheet_formatting.md).
 Para uma visão resumida em português do projeto Sequille, consulte [docs/descricao_resumida.md](docs/descricao_resumida.md).
 


### PR DESCRIPTION
## Summary
- reference WhatsApp ordering user stories in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683ced4d0fe0832eb73dff975aa204b1